### PR TITLE
[wip] Implement Fractional Voting - roll our own uint85s, truncate votes by 3 decimals

### DIFF
--- a/contracts/governance/extensions/GovernorCountingFractional.sol
+++ b/contracts/governance/extensions/GovernorCountingFractional.sol
@@ -137,17 +137,19 @@ abstract contract GovernorCountingFractional is Governor {
         );
         _proposalVotersHasVoted[proposalId][account] = true;
 
-        uint80 forVotes;
-        uint80 againstVotes;
-        uint80 abstainVotes;
+        // These are the variables we ultimately encode and pack as uint85's.
+        // Use a uint88 because it's the closest to a uint85 without undershooting.
+        uint88 forVotes;
+        uint88 againstVotes;
+        uint88 abstainVotes;
 
         if (params.length == 0) {
             if (support == uint8(VoteType.Against)) {
-                againstVotes = SafeCast.toUint80(weight / _votePrecision());
+                againstVotes = SafeCast.toUint88(weight / _votePrecision());
             } else if (support == uint8(VoteType.For)) {
-                forVotes = SafeCast.toUint80(weight / _votePrecision());
+                forVotes = SafeCast.toUint88(weight / _votePrecision());
             } else if (support == uint8(VoteType.Abstain)) {
-                abstainVotes = SafeCast.toUint80(weight / _votePrecision());
+                abstainVotes = SafeCast.toUint88(weight / _votePrecision());
             } else {
                 revert("GovernorCountingFractional: invalid value for enum VoteType");
             }
@@ -167,9 +169,9 @@ abstract contract GovernorCountingFractional is Governor {
                 _abstainVotes = uint128(weight) - _forVotes - _againstVotes;
             }
 
-            forVotes = SafeCast.toUint80(_forVotes / _votePrecision());
-            againstVotes = SafeCast.toUint80(_againstVotes / _votePrecision());
-            abstainVotes = SafeCast.toUint80(_abstainVotes / _votePrecision());
+            forVotes = SafeCast.toUint88(_forVotes / _votePrecision());
+            againstVotes = SafeCast.toUint88(_againstVotes / _votePrecision());
+            abstainVotes = SafeCast.toUint88(_abstainVotes / _votePrecision());
         }
 
         uint256 existingProposalVote = _proposalVotes[proposalId];

--- a/contracts/governance/extensions/GovernorCountingFractional.sol
+++ b/contracts/governance/extensions/GovernorCountingFractional.sol
@@ -43,7 +43,7 @@ abstract contract GovernorCountingFractional is Governor {
     /**
      * @dev Precision of vote counts. This many units of precision is discarded when storing votes.
      */
-    function VOTE_PRECISION() pure private returns (uint24) {
+    function _votePrecision() pure private returns (uint24) {
       return 1e6;
     }
 
@@ -69,9 +69,9 @@ abstract contract GovernorCountingFractional is Governor {
     {
         ProposalVote storage proposalvote = _proposalVotes[proposalId];
         return (
-          uint256(proposalvote.againstVotes) * VOTE_PRECISION(),
-          uint256(proposalvote.forVotes) * VOTE_PRECISION(),
-          uint256(proposalvote.abstainVotes) * VOTE_PRECISION()
+          uint256(proposalvote.againstVotes) * _votePrecision(),
+          uint256(proposalvote.forVotes) * _votePrecision(),
+          uint256(proposalvote.abstainVotes) * _votePrecision()
         );
     }
 
@@ -115,11 +115,11 @@ abstract contract GovernorCountingFractional is Governor {
 
         if (params.length == 0) {
             if (support == uint8(VoteType.Against)) {
-                againstVotes = SafeCast.toUint80(weight / VOTE_PRECISION());
+                againstVotes = SafeCast.toUint80(weight / _votePrecision());
             } else if (support == uint8(VoteType.For)) {
-                forVotes = SafeCast.toUint80(weight / VOTE_PRECISION());
+                forVotes = SafeCast.toUint80(weight / _votePrecision());
             } else if (support == uint8(VoteType.Abstain)) {
-                abstainVotes = SafeCast.toUint80(weight / VOTE_PRECISION());
+                abstainVotes = SafeCast.toUint80(weight / _votePrecision());
             } else {
                 revert("GovernorCountingFractional: invalid value for enum VoteType");
             }
@@ -139,9 +139,9 @@ abstract contract GovernorCountingFractional is Governor {
                 _abstainVotes = uint128(weight) - _forVotes - _againstVotes;
             }
 
-            forVotes = SafeCast.toUint80(_forVotes / VOTE_PRECISION());
-            againstVotes = SafeCast.toUint80(_againstVotes / VOTE_PRECISION());
-            abstainVotes = SafeCast.toUint80(_abstainVotes / VOTE_PRECISION());
+            forVotes = SafeCast.toUint80(_forVotes / _votePrecision());
+            againstVotes = SafeCast.toUint80(_againstVotes / _votePrecision());
+            abstainVotes = SafeCast.toUint80(_abstainVotes / _votePrecision());
         }
 
         ProposalVote memory existingProposalVote = _proposalVotes[proposalId];

--- a/contracts/governance/extensions/GovernorCountingFractional.sol
+++ b/contracts/governance/extensions/GovernorCountingFractional.sol
@@ -47,7 +47,7 @@ abstract contract GovernorCountingFractional is Governor {
      * @dev Precision of vote counts. This many units of precision is discarded when storing votes.
      */
     function _votePrecision() pure private returns (uint24) {
-      return 1e6;
+      return 1e3;
     }
 
     /**

--- a/contracts/governance/extensions/GovernorCountingFractional.sol
+++ b/contracts/governance/extensions/GovernorCountingFractional.sol
@@ -43,7 +43,7 @@ abstract contract GovernorCountingFractional is Governor {
     /**
      * @dev Precision of vote counts. This many units of precision is discarded when storing votes.
      */
-    function VOTE_PRECISION() pure private returns (uint24 memory) {
+    function VOTE_PRECISION() pure private returns (uint24) {
       return 1e6;
     }
 

--- a/contracts/governance/extensions/GovernorCountingFractional.sol
+++ b/contracts/governance/extensions/GovernorCountingFractional.sol
@@ -69,9 +69,9 @@ abstract contract GovernorCountingFractional is Governor {
     {
         ProposalVote storage proposalvote = _proposalVotes[proposalId];
         return (
-          SafeMath.tryMul(proposalvote.againstVotes, VOTE_PRECISION()),
-          SafeMath.tryMul(proposalvote.forVotes, VOTE_PRECISION()),
-          SafeMath.tryMul(proposalvote.abstainVotes, VOTE_PRECISION())
+          proposalvote.againstVotes * VOTE_PRECISION(),
+          proposalvote.forVotes * VOTE_PRECISION(),
+          proposalvote.abstainVotes * VOTE_PRECISION()
         );
     }
 

--- a/contracts/governance/extensions/GovernorCountingFractional.sol
+++ b/contracts/governance/extensions/GovernorCountingFractional.sol
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: MIT
+// OpenZeppelin Contracts v4.X.X (governance/extensions/GovernorCountingFractional.sol)
+
+pragma solidity ^0.8.0;
+
+import "../Governor.sol";
+
+/**
+ * @dev Extension of {Governor} for 3 option fractional vote counting.
+ *
+ * _Available since v4.X.X_
+ */
+abstract contract GovernorCountingFractional is Governor {
+    /**
+     * @dev Supported vote types. Matches Governor Bravo ordering.
+     */
+    enum VoteType {
+        Against,
+        For,
+        Abstain
+    }
+
+    struct ProposalVote {
+        uint256 againstVotes;
+        uint256 forVotes;
+        uint256 abstainVotes;
+        mapping(address => bool) hasVoted;
+    }
+
+    mapping(uint256 => ProposalVote) private _proposalVotes;
+
+    /**
+     * @dev See {IGovernor-COUNTING_MODE}.
+     * TODO: Add param for how params is used?
+     */
+    // solhint-disable-next-line func-name-mixedcase
+    function COUNTING_MODE() public pure virtual override returns (string memory) {
+        return "support=bravo&quorum=for,abstain";
+    }
+
+    /**
+     * @dev See {IGovernor-hasVoted}.
+     */
+    function hasVoted(uint256 proposalId, address account) public view virtual override returns (bool) {
+        return _proposalVotes[proposalId].hasVoted[account];
+    }
+
+    /**
+     * @dev Accessor to the internal vote counts.
+     */
+    function proposalVotes(uint256 proposalId)
+        public
+        view
+        virtual
+        returns (
+            uint256 againstVotes,
+            uint256 forVotes,
+            uint256 abstainVotes
+        )
+    {
+        ProposalVote storage proposalvote = _proposalVotes[proposalId];
+        return (proposalvote.againstVotes, proposalvote.forVotes, proposalvote.abstainVotes);
+    }
+
+    /**
+     * @dev See {Governor-_quorumReached}.
+     */
+    function _quorumReached(uint256 proposalId) internal view virtual override returns (bool) {
+        ProposalVote storage proposalvote = _proposalVotes[proposalId];
+
+        return quorum(proposalSnapshot(proposalId)) <= proposalvote.forVotes + proposalvote.abstainVotes;
+    }
+
+    /**
+     * @dev See {Governor-_voteSucceeded}. In this module, the forVotes must be strictly over the againstVotes.
+     */
+    function _voteSucceeded(uint256 proposalId) internal view virtual override returns (bool) {
+        ProposalVote storage proposalvote = _proposalVotes[proposalId];
+
+        return proposalvote.forVotes > proposalvote.againstVotes;
+    }
+
+    /**
+     * @dev See {Governor-_countVote}. In this module, the support follows the `VoteType` enum (from Governor Bravo).
+     */
+    function _countVote(
+        uint256 proposalId,
+        address account,
+        uint8 support,
+        uint256 weight,
+        bytes memory params
+    ) internal virtual override {
+        ProposalVote storage proposalvote = _proposalVotes[proposalId];
+
+        require(!proposalvote.hasVoted[account], "GovernorVotingSimple: vote already cast");
+        proposalvote.hasVoted[account] = true;
+
+        uint128 forVotes;
+        uint128 againstVotes;
+        uint128 abstainVotes;
+
+        if (params.length == 0) {
+            if (support == uint8(VoteType.Against)) {
+                againstVotes = uint128(weight);
+            } else if (support == uint8(VoteType.For)) {
+                forVotes = uint128(weight);
+            } else if (support == uint8(VoteType.Abstain)) {
+               abstainVotes = uint128(weight);
+            } else {
+                revert("GovernorCountingFractional: invalid value for enum VoteType");
+            }
+        } else {
+            (forVotes, againstVotes) = abi.decode(params, (uint128, uint128));
+            require(forVotes + againstVotes <= weight, "GovernorCountingFractional: Invalid Weight");
+            // prior require check ensures no overflow
+            unchecked {
+                abstainVotes = uint128(weight) - forVotes - againstVotes;
+            }
+        }
+
+        proposalvote.forVotes += forVotes;
+        proposalvote.againstVotes += againstVotes;
+        proposalvote.abstainVotes += abstainVotes;
+    }
+}

--- a/contracts/governance/extensions/GovernorCountingFractional.sol
+++ b/contracts/governance/extensions/GovernorCountingFractional.sol
@@ -28,7 +28,10 @@ abstract contract GovernorCountingFractional is Governor {
         uint80 abstainVotes;
     }
 
-    mapping(uint256 => ProposalVote) private _proposalVotes;
+    // proposal id --> encoded votes
+    mapping(uint256 => uint256) private _proposalVotes;
+
+    // proposal id --> (address --> whether the address voted)
     mapping(uint256 => mapping(address => bool)) private _proposalVotersHasVoted;
 
     /**
@@ -67,11 +70,20 @@ abstract contract GovernorCountingFractional is Governor {
             uint256 abstainVotes
         )
     {
-        ProposalVote storage proposalvote = _proposalVotes[proposalId];
+        uint256 _forVotes;
+        uint256 _againstVotes;
+        uint256 _abstainVotes;
+
+        (
+          _forVotes,
+          _againstVotes,
+          _abstainVotes
+        ) = _decodeVotes(_proposalVotes[proposalId]);
+
         return (
-          uint256(proposalvote.againstVotes) * _votePrecision(),
-          uint256(proposalvote.forVotes) * _votePrecision(),
-          uint256(proposalvote.abstainVotes) * _votePrecision()
+          _againstVotes * _votePrecision(),
+          _forVotes * _votePrecision(),
+          _abstainVotes * _votePrecision()
         );
     }
 
@@ -79,18 +91,34 @@ abstract contract GovernorCountingFractional is Governor {
      * @dev See {Governor-_quorumReached}.
      */
     function _quorumReached(uint256 proposalId) internal view virtual override returns (bool) {
-        ProposalVote storage proposalvote = _proposalVotes[proposalId];
+        uint256 _forVotes;
+        uint256 _abstainVotes;
 
-        return quorum(proposalSnapshot(proposalId)) <= proposalvote.forVotes + proposalvote.abstainVotes;
+        (
+          _forVotes,
+          , // _againstVotes
+          _abstainVotes
+        ) = _decodeVotes(_proposalVotes[proposalId]);
+
+        return quorum(proposalSnapshot(proposalId)) <= (
+          _forVotes + _abstainVotes
+        ) * _votePrecision();
     }
 
     /**
      * @dev See {Governor-_voteSucceeded}. In this module, the forVotes must be strictly over the againstVotes.
      */
     function _voteSucceeded(uint256 proposalId) internal view virtual override returns (bool) {
-        ProposalVote storage proposalvote = _proposalVotes[proposalId];
+        uint256 _forVotes;
+        uint256 _againstVotes;
 
-        return proposalvote.forVotes > proposalvote.againstVotes;
+        (
+          _forVotes,
+          _againstVotes
+          , // _abstainVotes
+        ) = _decodeVotes(_proposalVotes[proposalId]);
+
+        return _forVotes > _againstVotes;
     }
 
     /**
@@ -144,14 +172,54 @@ abstract contract GovernorCountingFractional is Governor {
             abstainVotes = SafeCast.toUint80(_abstainVotes / _votePrecision());
         }
 
-        ProposalVote memory existingProposalVote = _proposalVotes[proposalId];
+        uint256 existingProposalVote = _proposalVotes[proposalId];
 
-        ProposalVote memory _proposalvote = ProposalVote(
-          existingProposalVote.againstVotes + againstVotes,
-          existingProposalVote.forVotes + forVotes,
-          existingProposalVote.abstainVotes + abstainVotes
+        uint256 _existingForVotes;
+        uint256 _existingAgainstVotes;
+        uint256 _existingAbstainVotes;
+
+        (
+          _existingForVotes,
+          _existingAgainstVotes,
+          _existingAbstainVotes
+        ) = _decodeVotes(existingProposalVote);
+
+        _proposalVotes[proposalId] = _encodeVotes(
+          _existingForVotes + forVotes,
+          _existingAgainstVotes + againstVotes,
+          _existingAbstainVotes + abstainVotes
         );
+    }
 
-        _proposalVotes[proposalId] = _proposalvote;
+    uint256 public constant BITS = 85;
+    uint256 public constant MAX_UINT85 = 2 ** BITS - 1;
+    uint256 public constant MASK = 0x1fffffffffffffffffffff;
+
+    function _encodeVotes(
+      uint256 _for,
+      uint256 _against,
+      uint256 _abstain
+    ) internal pure returns(uint256) {
+      require(_for <= MAX_UINT85, "too many for votes");
+      require(_against <= MAX_UINT85, "too many against votes");
+      require(_abstain <= MAX_UINT85, "too many abstain votes");
+
+      // Shift by BITS to move the value to the correct position.
+      // x << y is equivalent to x * 2 ** y.
+      uint256 _shiftedFor = _for;
+      uint256 _shiftedAgainst = _against << BITS;
+      uint256 _shiftedAbstain = _abstain << BITS * 2;
+
+      return _shiftedAbstain | _shiftedAgainst | _shiftedFor;
+    }
+
+    function _decodeVotes(uint256 encodedVotes) internal pure returns (
+      uint256 _for,
+      uint256 _against,
+      uint256 _abstain
+    ) {
+      _for     = MASK & encodedVotes;
+      _against = MASK & encodedVotes >> BITS;
+      _abstain = MASK & encodedVotes >> BITS * 2;
     }
 }

--- a/contracts/governance/extensions/GovernorCountingFractional.sol
+++ b/contracts/governance/extensions/GovernorCountingFractional.sol
@@ -69,9 +69,9 @@ abstract contract GovernorCountingFractional is Governor {
     {
         ProposalVote storage proposalvote = _proposalVotes[proposalId];
         return (
-          proposalvote.againstVotes * VOTE_PRECISION(),
-          proposalvote.forVotes * VOTE_PRECISION(),
-          proposalvote.abstainVotes * VOTE_PRECISION()
+          uint256(proposalvote.againstVotes) * VOTE_PRECISION(),
+          uint256(proposalvote.forVotes) * VOTE_PRECISION(),
+          uint256(proposalvote.abstainVotes) * VOTE_PRECISION()
         );
     }
 

--- a/contracts/governance/extensions/GovernorCountingFractional.sol
+++ b/contracts/governance/extensions/GovernorCountingFractional.sol
@@ -21,9 +21,9 @@ abstract contract GovernorCountingFractional is Governor {
     }
 
     struct ProposalVote {
-        uint128 againstVotes;
-        uint128 forVotes;
-        uint128 abstainVotes;
+        uint80 againstVotes;
+        uint80 forVotes;
+        uint80 abstainVotes;
     }
 
     mapping(uint256 => ProposalVote) private _proposalVotes;
@@ -96,26 +96,26 @@ abstract contract GovernorCountingFractional is Governor {
         );
         _proposalVotersHasVoted[proposalId][account] = true;
 
-        uint128 forVotes;
-        uint128 againstVotes;
-        uint128 abstainVotes;
+        uint80 forVotes;
+        uint80 againstVotes;
+        uint80 abstainVotes;
 
         if (params.length == 0) {
             if (support == uint8(VoteType.Against)) {
-                againstVotes = uint128(weight);
+                againstVotes = uint80(weight);
             } else if (support == uint8(VoteType.For)) {
-                forVotes = uint128(weight);
+                forVotes = uint80(weight);
             } else if (support == uint8(VoteType.Abstain)) {
-               abstainVotes = uint128(weight);
+                abstainVotes = uint80(weight);
             } else {
                 revert("GovernorCountingFractional: invalid value for enum VoteType");
             }
         } else {
-            (forVotes, againstVotes) = abi.decode(params, (uint128, uint128));
+            (forVotes, againstVotes) = abi.decode(params, (uint80, uint80));
             require(forVotes + againstVotes <= weight, "GovernorCountingFractional: Invalid Weight");
             // prior require check ensures no overflow
             unchecked {
-                abstainVotes = uint128(weight) - forVotes - againstVotes;
+                abstainVotes = uint80(weight) - forVotes - againstVotes;
             }
         }
 

--- a/contracts/governance/extensions/GovernorCountingFractional.sol
+++ b/contracts/governance/extensions/GovernorCountingFractional.sol
@@ -22,9 +22,9 @@ abstract contract GovernorCountingFractional is Governor {
     }
 
     struct ProposalVote {
-        uint128 againstVotes;
-        uint128 forVotes;
-        uint128 abstainVotes;
+        uint80 againstVotes;
+        uint80 forVotes;
+        uint80 abstainVotes;
     }
 
     mapping(uint256 => ProposalVote) private _proposalVotes;
@@ -97,29 +97,29 @@ abstract contract GovernorCountingFractional is Governor {
         );
         _proposalVotersHasVoted[proposalId][account] = true;
 
-        uint128 forVotes;
-        uint128 againstVotes;
-        uint128 abstainVotes;
+        uint80 forVotes;
+        uint80 againstVotes;
+        uint80 abstainVotes;
 
         if (params.length == 0) {
             if (support == uint8(VoteType.Against)) {
-                againstVotes = SafeCast.toUint128(weight);
+                againstVotes = SafeCast.toUint80(weight);
             } else if (support == uint8(VoteType.For)) {
-                forVotes = SafeCast.toUint128(weight);
+                forVotes = SafeCast.toUint80(weight);
             } else if (support == uint8(VoteType.Abstain)) {
-                abstainVotes = SafeCast.toUint128(weight);
+                abstainVotes = SafeCast.toUint80(weight);
             } else {
                 revert("GovernorCountingFractional: invalid value for enum VoteType");
             }
         } else {
-            (forVotes, againstVotes) = abi.decode(params, (uint128, uint128));
+            (forVotes, againstVotes) = abi.decode(params, (uint80, uint80));
             require(
-              forVotes + againstVotes <= SafeCast.toUint128(weight),
+              forVotes + againstVotes <= SafeCast.toUint80(weight),
               "GovernorCountingFractional: Invalid Weight"
             );
-            // prior require check ensures no overflow
+            // prior require check ensures no overflow and safe casting
             unchecked {
-                abstainVotes = uint128(weight) - forVotes - againstVotes;
+                abstainVotes = uint80(weight) - forVotes - againstVotes;
             }
         }
 

--- a/contracts/governance/extensions/GovernorCountingFractional.sol
+++ b/contracts/governance/extensions/GovernorCountingFractional.sol
@@ -21,9 +21,9 @@ abstract contract GovernorCountingFractional is Governor {
     }
 
     struct ProposalVote {
-        uint256 againstVotes;
-        uint256 forVotes;
-        uint256 abstainVotes;
+        uint128 againstVotes;
+        uint128 forVotes;
+        uint128 abstainVotes;
         mapping(address => bool) hasVoted;
     }
 

--- a/contracts/mocks/GovernorFractionalMock.sol
+++ b/contracts/mocks/GovernorFractionalMock.sol
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: MIT
+
+pragma solidity ^0.8.0;
+
+import "../governance/extensions/GovernorCountingFractional.sol";
+import "../governance/extensions/GovernorVotes.sol";
+
+contract GovernorFractionalMock is GovernorVotes, GovernorCountingFractional {
+
+    constructor(string memory name_, IVotes token_) Governor(name_) GovernorVotes(token_) {}
+
+    function quorum(uint256) public pure override returns (uint256) {
+        return 0;
+    }
+
+    function votingDelay() public pure override returns (uint256) {
+        return 4;
+    }
+
+    function votingPeriod() public pure override returns (uint256) {
+        return 16;
+    }
+
+    function cancel(
+        address[] memory targets,
+        uint256[] memory values,
+        bytes[] memory calldatas,
+        bytes32 salt
+    ) public returns (uint256 proposalId) {
+        return _cancel(targets, values, calldatas, salt);
+    }
+}

--- a/contracts/mocks/SafeCastMock.sol
+++ b/contracts/mocks/SafeCastMock.sol
@@ -24,6 +24,10 @@ contract SafeCastMock {
         return a.toUint96();
     }
 
+    function toUint80(uint256 a) public pure returns (uint80) {
+        return a.toUint80();
+    }
+
     function toUint64(uint256 a) public pure returns (uint64) {
         return a.toUint64();
     }

--- a/contracts/mocks/SafeCastMock.sol
+++ b/contracts/mocks/SafeCastMock.sol
@@ -24,6 +24,10 @@ contract SafeCastMock {
         return a.toUint96();
     }
 
+    function toUint88(uint256 a) public pure returns (uint88) {
+        return a.toUint88();
+    }
+
     function toUint80(uint256 a) public pure returns (uint80) {
         return a.toUint80();
     }

--- a/contracts/utils/Address.sol
+++ b/contracts/utils/Address.sol
@@ -193,8 +193,8 @@ library Address {
     }
 
     /**
-     * @dev Tool to verifies that a low level call was successful, and revert if it wasn't, either by bubbling the
-     * revert reason using the provided one.
+     * @dev Tool to verify that a low level call was successful, and revert if it wasn't, either by bubbling the
+     * revert reason or using the provided one.
      *
      * _Available since v4.3._
      */

--- a/contracts/utils/math/SafeCast.sol
+++ b/contracts/utils/math/SafeCast.sol
@@ -65,6 +65,21 @@ library SafeCast {
     }
 
     /**
+     * @dev Returns the downcasted uint80 from uint256, reverting on
+     * overflow (when the input is greater than largest uint80).
+     *
+     * Counterpart to Solidity's `uint80` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 80 bits
+     */
+    function toUint80(uint256 value) internal pure returns (uint80) {
+        require(value <= type(uint80).max, "SafeCast: value doesn't fit in 80 bits");
+        return uint80(value);
+    }
+
+    /**
      * @dev Returns the downcasted uint64 from uint256, reverting on
      * overflow (when the input is greater than largest uint64).
      *

--- a/contracts/utils/math/SafeCast.sol
+++ b/contracts/utils/math/SafeCast.sol
@@ -65,6 +65,21 @@ library SafeCast {
     }
 
     /**
+     * @dev Returns the downcasted uint88 from uint256, reverting on
+     * overflow (when the input is greater than largest uint88).
+     *
+     * Counterpart to Solidity's `uint88` operator.
+     *
+     * Requirements:
+     *
+     * - input must fit into 88 bits
+     */
+    function toUint88(uint256 value) internal pure returns (uint88) {
+        require(value <= type(uint88).max, "SafeCast: value doesn't fit in 88 bits");
+        return uint88(value);
+    }
+
+    /**
      * @dev Returns the downcasted uint80 from uint256, reverting on
      * overflow (when the input is greater than largest uint80).
      *

--- a/test/governance/extensions/GovernorCountingFractional.test.js
+++ b/test/governance/extensions/GovernorCountingFractional.test.js
@@ -139,7 +139,7 @@ contract('GovernorCountingFractional', function (accounts) {
       const againstVotes = new BN(voter2Weight).mul(new BN(20)).div(new BN(100)); // 20 percent Against
       const abstainVotes = new BN(voter2Weight).sub(forVotes).sub(againstVotes);
 
-      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
 
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
@@ -182,7 +182,7 @@ contract('GovernorCountingFractional', function (accounts) {
       const againstVotes = new BN(0);
       const abstainVotes = new BN(voter2Weight);
 
-      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
 
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
@@ -225,7 +225,7 @@ contract('GovernorCountingFractional', function (accounts) {
       const againstVotes = new BN(0);
       const abstainVotes = new BN(0);
 
-      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
 
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
@@ -268,7 +268,7 @@ contract('GovernorCountingFractional', function (accounts) {
       const againstVotes = new BN(voter2Weight);
       const abstainVotes = new BN(0);
 
-      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
 
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
@@ -319,7 +319,7 @@ contract('GovernorCountingFractional', function (accounts) {
       const voter3AbstainVotes = new BN(voter3Weight).sub(voter3ForVotes).sub(voter3AgainstVotes);
 
       // voter 2 casts votes
-      const voter2Params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [voter2ForVotes, voter2AgainstVotes]);
+      const voter2Params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [voter2ForVotes, voter2AgainstVotes]);
       const voter2Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', voter2Params, { from: voter2 });
       expectEvent(voter2Tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params: voter2Params });
       let votes = await this.mock.proposalVotes(this.id);
@@ -328,7 +328,7 @@ contract('GovernorCountingFractional', function (accounts) {
       expect(votes.abstainVotes).to.be.bignumber.equal(voter2AbstainVotes);
 
       // voter 2 casts votes
-      const voter3Params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [voter3ForVotes, voter3AgainstVotes]);
+      const voter3Params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [voter3ForVotes, voter3AgainstVotes]);
       const voter3Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', voter3Params, { from: voter3 });
       expectEvent(voter3Tx, 'VoteCastWithParams', { voter: voter3, weight: voter3Weight, params: voter3Params });
       votes = await this.mock.proposalVotes(this.id);
@@ -376,7 +376,7 @@ contract('GovernorCountingFractional', function (accounts) {
       const againstVotes = new BN(voter2Weight).mul(new BN(1)).div(new BN(100)); // 1%
       const abstainVotes = new BN(voter2Weight).sub(forVotes).sub(againstVotes);
 
-      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
 
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
@@ -432,7 +432,7 @@ contract('GovernorCountingFractional', function (accounts) {
       const againstVotes = new BN(voter2Weight).mul(new BN(90)).div(new BN(100)); // 90%
       const abstainVotes = new BN(voter2Weight).sub(forVotes).sub(againstVotes);
 
-      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
 
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
@@ -487,7 +487,7 @@ contract('GovernorCountingFractional', function (accounts) {
 
       assert(forVotes.add(againstVotes).gt(new BN(voter2Weight)), 'test assumption not met');
 
-      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
       await expectRevert(
         this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 }),
         'GovernorCountingFractional: Invalid Weight',

--- a/test/governance/extensions/GovernorCountingFractional.test.js
+++ b/test/governance/extensions/GovernorCountingFractional.test.js
@@ -1,0 +1,154 @@
+const { BN, constants, expectEvent } = require('@openzeppelin/test-helpers');
+const { web3 } = require('@openzeppelin/test-helpers/src/setup');
+const Enums = require('../../helpers/enums');
+const ethSigUtil = require('eth-sig-util');
+const Wallet = require('ethereumjs-wallet').default;
+const { EIP712Domain } = require('../../helpers/eip712');
+const { fromRpcSig } = require('ethereumjs-util');
+
+const { runGovernorWorkflow } = require('../GovernorWorkflow.behavior');
+const { expect } = require('chai');
+
+const Token = artifacts.require('ERC20VotesCompMock');
+const Governor = artifacts.require('GovernorFractionalMock');
+const CallReceiver = artifacts.require('CallReceiverMock');
+
+contract('GovernorCountingFractional', function (accounts) {
+  const [owner, proposer, voter1, voter2, voter3, voter4] = accounts;
+
+  const name = 'OZ-Governor';
+  const version = '1';
+  const tokenName = 'MockToken';
+  const tokenSymbol = 'MTKN';
+  const tokenSupply = web3.utils.toWei('100');
+  const votingDelay = new BN(4);
+  const votingPeriod = new BN(16);
+
+  beforeEach(async function () {
+    this.owner = owner;
+    this.token = await Token.new(tokenName, tokenSymbol);
+    this.mock = await Governor.new(name, this.token.address);
+    this.receiver = await CallReceiver.new();
+    await this.token.mint(owner, tokenSupply);
+    await this.token.delegate(voter1, { from: voter1 });
+    await this.token.delegate(voter2, { from: voter2 });
+    await this.token.delegate(voter3, { from: voter3 });
+    await this.token.delegate(voter4, { from: voter4 });
+  });
+
+  it('deployment check', async function () {
+    expect(await this.mock.name()).to.be.equal(name);
+    expect(await this.mock.token()).to.be.equal(this.token.address);
+    expect(await this.mock.votingDelay()).to.be.bignumber.equal(votingDelay);
+    expect(await this.mock.votingPeriod()).to.be.bignumber.equal(votingPeriod);
+  });
+
+  describe('nominal is unaffected', function () {
+    beforeEach(async function () {
+      this.settings = {
+        proposal: [
+          [this.receiver.address],
+          [0],
+          [this.receiver.contract.methods.mockFunction().encodeABI()],
+          '<proposal description>',
+        ],
+        proposer,
+        tokenHolder: owner,
+        voters: [
+          { voter: voter1, weight: web3.utils.toWei('1'), support: Enums.VoteType.For, reason: 'This is nice' },
+          { voter: voter2, weight: web3.utils.toWei('7'), support: Enums.VoteType.For },
+          { voter: voter3, weight: web3.utils.toWei('5'), support: Enums.VoteType.Against },
+          { voter: voter4, weight: web3.utils.toWei('2'), support: Enums.VoteType.Abstain },
+        ],
+      };
+    });
+
+    afterEach(async function () {
+      expect(await this.mock.hasVoted(this.id, owner)).to.be.equal(false);
+      expect(await this.mock.hasVoted(this.id, voter1)).to.be.equal(true);
+      expect(await this.mock.hasVoted(this.id, voter2)).to.be.equal(true);
+
+      await this.mock.proposalVotes(this.id).then((result) => {
+        for (const [key, value] of Object.entries(Enums.VoteType)) {
+          expect(result[`${key.toLowerCase()}Votes`]).to.be.bignumber.equal(
+            Object.values(this.settings.voters)
+              .filter(({ support }) => support === value)
+              .reduce((acc, { weight }) => acc.add(new BN(weight)), new BN('0')),
+          );
+        }
+      });
+
+      const startBlock = new BN(this.receipts.propose.blockNumber).add(votingDelay);
+      const endBlock = new BN(this.receipts.propose.blockNumber).add(votingDelay).add(votingPeriod);
+      expect(await this.mock.proposalSnapshot(this.id)).to.be.bignumber.equal(startBlock);
+      expect(await this.mock.proposalDeadline(this.id)).to.be.bignumber.equal(endBlock);
+
+      expectEvent(this.receipts.propose, 'ProposalCreated', {
+        proposalId: this.id,
+        proposer,
+        targets: this.settings.proposal[0],
+        // values: this.settings.proposal[1].map(value => new BN(value)),
+        signatures: this.settings.proposal[2].map(() => ''),
+        calldatas: this.settings.proposal[2],
+        startBlock,
+        endBlock,
+        description: this.settings.proposal[3],
+      });
+
+      this.receipts.castVote.filter(Boolean).forEach((vote) => {
+        const { voter } = vote.logs.filter(({ event }) => event === 'VoteCast').find(Boolean).args;
+        expectEvent(
+          vote,
+          'VoteCast',
+          this.settings.voters.find(({ address }) => address === voter),
+        );
+      });
+      expectEvent(this.receipts.execute, 'ProposalExecuted', { proposalId: this.id });
+      await expectEvent.inTransaction(this.receipts.execute.transactionHash, this.receiver, 'MockFunctionCalled');
+    });
+    runGovernorWorkflow();
+  });
+
+  describe('Voting with fractionalized parameters is properly supported', function () {
+    const voter1Weight = web3.utils.toWei('0.2');
+    const voter2Weight = web3.utils.toWei('10.0');
+    beforeEach(async function () {
+      this.settings = {
+        proposal: [
+          [this.receiver.address],
+          [0],
+          [this.receiver.contract.methods.mockFunction().encodeABI()],
+          '<proposal description>',
+        ],
+        proposer,
+        tokenHolder: owner,
+        voters: [
+          { voter: voter1, weight: voter1Weight, support: Enums.VoteType.Against },
+          { voter: voter2, weight: voter2Weight }, // do not actually vote, only getting tokens
+        ],
+        steps: {
+          wait: { enable: false },
+          execute: { enable: false },
+        },
+      };
+    });
+
+    afterEach(async function () {
+      expect(await this.mock.state(this.id)).to.be.bignumber.equal(Enums.ProposalState.Active);
+
+      const forVotes = (new BN(voter2Weight)).mul(new BN(70)).div(new BN(100)); // 70 percent For
+      const againstVotes = (new BN(voter2Weight)).mul(new BN(20)).div(new BN(100)); // 20 percent Against
+      const abstainVotes = (new BN(voter2Weight)).sub(forVotes).sub(againstVotes);
+
+      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
+      const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
+
+      expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
+      const votes = await this.mock.proposalVotes(this.id);
+      expect(votes.forVotes).to.be.bignumber.equal(forVotes);
+      expect(votes.againstVotes).to.be.bignumber.equal((new BN(voter1Weight)).add(againstVotes))
+      expect(votes.abstainVotes).to.be.bignumber.equal(abstainVotes);
+    });
+    runGovernorWorkflow();
+  });
+});

--- a/test/governance/extensions/GovernorCountingFractional.test.js
+++ b/test/governance/extensions/GovernorCountingFractional.test.js
@@ -1,7 +1,6 @@
-const { BN, constants, expectEvent, expectRevert, time } = require('@openzeppelin/test-helpers');
+const { BN, expectEvent, expectRevert, time } = require('@openzeppelin/test-helpers');
 const { web3 } = require('@openzeppelin/test-helpers/src/setup');
 const Enums = require('../../helpers/enums');
-const ethSigUtil = require('eth-sig-util');
 const Wallet = require('ethereumjs-wallet').default;
 const { EIP712Domain } = require('../../helpers/eip712');
 const { fromRpcSig } = require('ethereumjs-util');
@@ -136,9 +135,9 @@ contract('GovernorCountingFractional', function (accounts) {
     afterEach(async function () {
       expect(await this.mock.state(this.id)).to.be.bignumber.equal(Enums.ProposalState.Active);
 
-      const forVotes = (new BN(voter2Weight)).mul(new BN(70)).div(new BN(100)); // 70 percent For
-      const againstVotes = (new BN(voter2Weight)).mul(new BN(20)).div(new BN(100)); // 20 percent Against
-      const abstainVotes = (new BN(voter2Weight)).sub(forVotes).sub(againstVotes);
+      const forVotes = new BN(voter2Weight).mul(new BN(70)).div(new BN(100)); // 70 percent For
+      const againstVotes = new BN(voter2Weight).mul(new BN(20)).div(new BN(100)); // 20 percent Against
+      const abstainVotes = new BN(voter2Weight).sub(forVotes).sub(againstVotes);
 
       const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
@@ -146,7 +145,7 @@ contract('GovernorCountingFractional', function (accounts) {
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
       const votes = await this.mock.proposalVotes(this.id);
       expect(votes.forVotes).to.be.bignumber.equal(forVotes);
-      expect(votes.againstVotes).to.be.bignumber.equal((new BN(voter1Weight)).add(againstVotes))
+      expect(votes.againstVotes).to.be.bignumber.equal(new BN(voter1Weight).add(againstVotes));
       expect(votes.abstainVotes).to.be.bignumber.equal(abstainVotes);
     });
     runGovernorWorkflow();
@@ -189,7 +188,7 @@ contract('GovernorCountingFractional', function (accounts) {
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
       const votes = await this.mock.proposalVotes(this.id);
       expect(votes.forVotes).to.be.bignumber.equal(forVotes);
-      expect(votes.againstVotes).to.be.bignumber.equal((new BN(voter1Weight)).add(againstVotes))
+      expect(votes.againstVotes).to.be.bignumber.equal(new BN(voter1Weight).add(againstVotes));
       expect(votes.abstainVotes).to.be.bignumber.equal(abstainVotes);
     });
     runGovernorWorkflow();
@@ -232,7 +231,7 @@ contract('GovernorCountingFractional', function (accounts) {
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
       const votes = await this.mock.proposalVotes(this.id);
       expect(votes.forVotes).to.be.bignumber.equal(forVotes);
-      expect(votes.againstVotes).to.be.bignumber.equal((new BN(voter1Weight)).add(againstVotes))
+      expect(votes.againstVotes).to.be.bignumber.equal(new BN(voter1Weight).add(againstVotes));
       expect(votes.abstainVotes).to.be.bignumber.equal(abstainVotes);
     });
     runGovernorWorkflow();
@@ -275,7 +274,7 @@ contract('GovernorCountingFractional', function (accounts) {
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
       const votes = await this.mock.proposalVotes(this.id);
       expect(votes.forVotes).to.be.bignumber.equal(forVotes);
-      expect(votes.againstVotes).to.be.bignumber.equal((new BN(voter1Weight)).add(againstVotes))
+      expect(votes.againstVotes).to.be.bignumber.equal(new BN(voter1Weight).add(againstVotes));
       expect(votes.abstainVotes).to.be.bignumber.equal(abstainVotes);
     });
     runGovernorWorkflow();
@@ -311,38 +310,32 @@ contract('GovernorCountingFractional', function (accounts) {
     afterEach(async function () {
       expect(await this.mock.state(this.id)).to.be.bignumber.equal(Enums.ProposalState.Active);
 
-      const voter2ForVotes = (new BN(voter2Weight)).mul(new BN(70)).div(new BN(100)); // 70%
-      const voter2AgainstVotes = (new BN(voter2Weight)).mul(new BN(20)).div(new BN(100)); // 20%
-      const voter2AbstainVotes = (new BN(voter2Weight)).sub(voter2ForVotes).sub(voter2AgainstVotes);
+      const voter2ForVotes = new BN(voter2Weight).mul(new BN(70)).div(new BN(100)); // 70%
+      const voter2AgainstVotes = new BN(voter2Weight).mul(new BN(20)).div(new BN(100)); // 20%
+      const voter2AbstainVotes = new BN(voter2Weight).sub(voter2ForVotes).sub(voter2AgainstVotes);
 
-      const voter3ForVotes = (new BN(voter3Weight)).mul(new BN(15)).div(new BN(100)); // 15%
-      const voter3AgainstVotes = (new BN(voter3Weight)).mul(new BN(80)).div(new BN(100)); // 80%
-      const voter3AbstainVotes = (new BN(voter3Weight)).sub(voter3ForVotes).sub(voter3AgainstVotes);
+      const voter3ForVotes = new BN(voter3Weight).mul(new BN(15)).div(new BN(100)); // 15%
+      const voter3AgainstVotes = new BN(voter3Weight).mul(new BN(80)).div(new BN(100)); // 80%
+      const voter3AbstainVotes = new BN(voter3Weight).sub(voter3ForVotes).sub(voter3AgainstVotes);
 
       // voter 2 casts votes
       const voter2Params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [voter2ForVotes, voter2AgainstVotes]);
       const voter2Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', voter2Params, { from: voter2 });
-      expectEvent(
-        voter2Tx,
-        'VoteCastWithParams',
-        { voter: voter2, weight: voter2Weight, params: voter2Params }
-      );
+      expectEvent(voter2Tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params: voter2Params });
       let votes = await this.mock.proposalVotes(this.id);
       expect(votes.forVotes).to.be.bignumber.equal(voter2ForVotes);
-      expect(votes.againstVotes).to.be.bignumber.equal((new BN(voter1Weight)).add(voter2AgainstVotes))
+      expect(votes.againstVotes).to.be.bignumber.equal(new BN(voter1Weight).add(voter2AgainstVotes));
       expect(votes.abstainVotes).to.be.bignumber.equal(voter2AbstainVotes);
 
       // voter 2 casts votes
       const voter3Params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [voter3ForVotes, voter3AgainstVotes]);
-const voter3Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', voter3Params, { from: voter3 });
-      expectEvent(
-        voter3Tx,
-        'VoteCastWithParams',
-        { voter: voter3, weight: voter3Weight, params: voter3Params }
-      );
+      const voter3Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', voter3Params, { from: voter3 });
+      expectEvent(voter3Tx, 'VoteCastWithParams', { voter: voter3, weight: voter3Weight, params: voter3Params });
       votes = await this.mock.proposalVotes(this.id);
       expect(votes.forVotes).to.be.bignumber.equal(voter3ForVotes.add(voter2ForVotes));
-      expect(votes.againstVotes).to.be.bignumber.equal((new BN(voter1Weight)).add(voter2AgainstVotes).add(voter3AgainstVotes))
+      expect(votes.againstVotes).to.be.bignumber.equal(
+        new BN(voter1Weight).add(voter2AgainstVotes).add(voter3AgainstVotes),
+      );
       expect(votes.abstainVotes).to.be.bignumber.equal(voter3AbstainVotes.add(voter2AbstainVotes));
     });
 
@@ -379,9 +372,9 @@ const voter3Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', vot
     afterEach(async function () {
       expect(await this.mock.state(this.id)).to.be.bignumber.equal(Enums.ProposalState.Active);
 
-      const forVotes = (new BN(voter2Weight)).mul(new BN(98)).div(new BN(100)); // 98%
-      const againstVotes = (new BN(voter2Weight)).mul(new BN(1)).div(new BN(100)); // 1%
-      const abstainVotes = (new BN(voter2Weight)).sub(forVotes).sub(againstVotes);
+      const forVotes = new BN(voter2Weight).mul(new BN(98)).div(new BN(100)); // 98%
+      const againstVotes = new BN(voter2Weight).mul(new BN(1)).div(new BN(100)); // 1%
+      const abstainVotes = new BN(voter2Weight).sub(forVotes).sub(againstVotes);
 
       const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
@@ -395,7 +388,7 @@ const voter3Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', vot
       // execute the proposal
       const executer = voter2;
       const proposal = this.settings.shortProposal; // defined in GovernorWorkflow.behavior
-      const executeFn = this.mock.methods['execute(address[],uint256[],bytes[],bytes32)']
+      const executeFn = this.mock.methods['execute(address[],uint256[],bytes[],bytes32)'];
       const executionTx = await executeFn(...proposal, { from: executer });
 
       expectEvent(executionTx, 'ProposalExecuted', { proposalId: this.id });
@@ -435,9 +428,9 @@ const voter3Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', vot
     afterEach(async function () {
       expect(await this.mock.state(this.id)).to.be.bignumber.equal(Enums.ProposalState.Active);
 
-      const forVotes = (new BN(voter2Weight)).mul(new BN(1)).div(new BN(100)); // 1%
-      const againstVotes = (new BN(voter2Weight)).mul(new BN(90)).div(new BN(100)); // 90%
-      const abstainVotes = (new BN(voter2Weight)).sub(forVotes).sub(againstVotes);
+      const forVotes = new BN(voter2Weight).mul(new BN(1)).div(new BN(100)); // 1%
+      const againstVotes = new BN(voter2Weight).mul(new BN(90)).div(new BN(100)); // 90%
+      const abstainVotes = new BN(voter2Weight).sub(forVotes).sub(againstVotes);
 
       const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
@@ -450,11 +443,8 @@ const voter3Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', vot
       // try to execute the proposal
       const executer = voter2;
       const proposal = this.settings.shortProposal; // defined in GovernorWorkflow.behavior
-      const executeFn = this.mock.methods['execute(address[],uint256[],bytes[],bytes32)']
-      await expectRevert(
-        executeFn(...proposal, { from: executer }),
-        'Governor: proposal not successful'
-      );
+      const executeFn = this.mock.methods['execute(address[],uint256[],bytes[],bytes32)'];
+      await expectRevert(executeFn(...proposal, { from: executer }), 'Governor: proposal not successful');
 
       expect(await this.mock.state(this.id)).to.be.bignumber.equal(Enums.ProposalState.Defeated);
     });
@@ -491,19 +481,16 @@ const voter3Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', vot
     afterEach(async function () {
       expect(await this.mock.state(this.id)).to.be.bignumber.equal(Enums.ProposalState.Active);
 
-      const forVotes = (new BN(voter2Weight)).mul(new BN(56)).div(new BN(100)); // 56%
-      const againstVotes = (new BN(voter2Weight)).mul(new BN(90)).div(new BN(100)); // 90%
-      const abstainVotes = (new BN(voter2Weight)).sub(forVotes).sub(againstVotes);
+      const forVotes = new BN(voter2Weight).mul(new BN(56)).div(new BN(100)); // 56%
+      const againstVotes = new BN(voter2Weight).mul(new BN(90)).div(new BN(100)); // 90%
+      const abstainVotes = new BN(voter2Weight).sub(forVotes).sub(againstVotes);
 
-      assert(
-        forVotes.add(againstVotes).gt(new BN(voter2Weight)),
-        "test assumption not met"
-      )
+      assert(forVotes.add(againstVotes).gt(new BN(voter2Weight)), 'test assumption not met');
 
       const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
       await expectRevert(
         this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 }),
-        'GovernorCountingFractional: Invalid Weight'
+        'GovernorCountingFractional: Invalid Weight',
       );
     });
 

--- a/test/governance/extensions/GovernorCountingFractional.test.js
+++ b/test/governance/extensions/GovernorCountingFractional.test.js
@@ -647,16 +647,16 @@ contract('GovernorCountingFractional', function (accounts) {
       const votes = await this.mock.proposalVotes(this.id);
       expect(votes.againstVotes).to.be.bignumber.equal(new BN('0'));
       expect(votes.abstainVotes).to.be.bignumber.equal(new BN('0'));
-      expect(votes.forVotes).to.be.bignumber.equal(new BN('42424242424242424242000000'));
+      expect(votes.forVotes).to.be.bignumber.equal(new BN('42424242424242424242424000'));
     });
 
     runGovernorWorkflow();
   });
 
   describe('It correctly adds votes after stripping precision', function () {
-    // we strip precision starting .....      v here
-    const voter1Weight = '33333333333333333333111111';
-    const voter2Weight = '11111111111111111111999999';
+    // we strip precision starting ............. here
+    const voter1Weight = '33333333333333333333333111';
+    const voter2Weight = '11111111111111111111111999';
     beforeEach(async function () {
       this.settings = {
         proposal: [
@@ -685,16 +685,16 @@ contract('GovernorCountingFractional', function (accounts) {
       const votes = await this.mock.proposalVotes(this.id);
       expect(votes.againstVotes).to.be.bignumber.equal(new BN('0'));
       expect(votes.abstainVotes).to.be.bignumber.equal(new BN('0'));
-      expect(votes.forVotes).to.be.bignumber.equal(new BN('44444444444444444444000000'));
+      expect(votes.forVotes).to.be.bignumber.equal(new BN('44444444444444444444444000'));
     });
 
     runGovernorWorkflow();
   });
 
   describe('It correctly adds fractional votes after stripping precision', function () {
-    // we strip precision  v here
-    const voter1Weight = '2999999';
-    const voter2Weight = '9000001';
+    // we strip precision     v here
+    const voter1Weight = '2999900';
+    const voter2Weight = '9000100';
     beforeEach(async function () {
       this.settings = {
         proposal: [
@@ -722,7 +722,7 @@ contract('GovernorCountingFractional', function (accounts) {
       expect(await this.mock.state(this.id)).to.be.bignumber.equal(Enums.ProposalState.Active);
 
       const forVotes = new BN('9000000');
-      const againstVotes = new BN('1');
+      const againstVotes = new BN('100');
       const abstainVotes = new BN(voter2Weight).sub(forVotes).sub(againstVotes);
 
       const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
@@ -731,8 +731,8 @@ contract('GovernorCountingFractional', function (accounts) {
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
       const votes = await this.mock.proposalVotes(this.id);
       expect(votes.forVotes).to.be.bignumber.equal(forVotes);
-      // the votes have been stripped
-      expect(votes.againstVotes).to.be.bignumber.equal(new BN('2000000'));
+      // the votes have been stripped and the (partial) against votes were lost
+      expect(votes.againstVotes).to.be.bignumber.equal(new BN('2999000'));
       expect(votes.abstainVotes).to.be.bignumber.equal(abstainVotes);
     });
 

--- a/test/governance/extensions/GovernorCountingFractional.test.js
+++ b/test/governance/extensions/GovernorCountingFractional.test.js
@@ -140,7 +140,7 @@ contract('GovernorCountingFractional', function (accounts) {
       const againstVotes = (new BN(voter2Weight)).mul(new BN(20)).div(new BN(100)); // 20 percent Against
       const abstainVotes = (new BN(voter2Weight)).sub(forVotes).sub(againstVotes);
 
-      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
 
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
@@ -183,7 +183,7 @@ contract('GovernorCountingFractional', function (accounts) {
       const againstVotes = new BN(0);
       const abstainVotes = new BN(voter2Weight);
 
-      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
 
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
@@ -226,7 +226,7 @@ contract('GovernorCountingFractional', function (accounts) {
       const againstVotes = new BN(0);
       const abstainVotes = new BN(0);
 
-      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
 
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
@@ -269,7 +269,7 @@ contract('GovernorCountingFractional', function (accounts) {
       const againstVotes = new BN(voter2Weight);
       const abstainVotes = new BN(0);
 
-      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
 
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
@@ -320,7 +320,7 @@ contract('GovernorCountingFractional', function (accounts) {
       const voter3AbstainVotes = (new BN(voter3Weight)).sub(voter3ForVotes).sub(voter3AgainstVotes);
 
       // voter 2 casts votes
-      const voter2Params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [voter2ForVotes, voter2AgainstVotes]);
+      const voter2Params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [voter2ForVotes, voter2AgainstVotes]);
       const voter2Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', voter2Params, { from: voter2 });
       expectEvent(
         voter2Tx,
@@ -333,7 +333,7 @@ contract('GovernorCountingFractional', function (accounts) {
       expect(votes.abstainVotes).to.be.bignumber.equal(voter2AbstainVotes);
 
       // voter 2 casts votes
-      const voter3Params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [voter3ForVotes, voter3AgainstVotes]);
+      const voter3Params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [voter3ForVotes, voter3AgainstVotes]);
 const voter3Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', voter3Params, { from: voter3 });
       expectEvent(
         voter3Tx,
@@ -383,7 +383,7 @@ const voter3Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', vot
       const againstVotes = (new BN(voter2Weight)).mul(new BN(1)).div(new BN(100)); // 1%
       const abstainVotes = (new BN(voter2Weight)).sub(forVotes).sub(againstVotes);
 
-      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
 
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
@@ -439,7 +439,7 @@ const voter3Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', vot
       const againstVotes = (new BN(voter2Weight)).mul(new BN(90)).div(new BN(100)); // 90%
       const abstainVotes = (new BN(voter2Weight)).sub(forVotes).sub(againstVotes);
 
-      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
 
       expectEvent(tx, 'VoteCastWithParams', { voter: voter2, weight: voter2Weight, params });
@@ -500,7 +500,7 @@ const voter3Tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', vot
         "test assumption not met"
       )
 
-      const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
+      const params = web3.eth.abi.encodeParameters(['uint80', 'uint80'], [forVotes, againstVotes]);
       await expectRevert(
         this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 }),
         'GovernorCountingFractional: Invalid Weight'

--- a/test/governance/extensions/GovernorCountingFractional.test.js
+++ b/test/governance/extensions/GovernorCountingFractional.test.js
@@ -5,7 +5,10 @@ const Enums = require('../../helpers/enums');
 const { runGovernorWorkflow } = require('../GovernorWorkflow.behavior');
 const { expect, assert } = require('chai');
 
-const Token = artifacts.require('ERC20VotesCompMock');
+// we are using this instead of ERC20VotesComp because we need a really big
+// token supply to do overflow testing -- more than ERC20VotesComp's maxSupply
+const Token = artifacts.require('ERC20VotesMock');
+
 const Governor = artifacts.require('GovernorFractionalMock');
 const CallReceiver = artifacts.require('CallReceiverMock');
 
@@ -15,7 +18,8 @@ contract('GovernorCountingFractional', function (accounts) {
   const name = 'OZ-Governor';
   const tokenName = 'MockToken';
   const tokenSymbol = 'MTKN';
-  const tokenSupply = web3.utils.toWei('9000000'); // needed for overflow testing
+  // we need a really big supply to do overflow testing
+  const tokenSupply = web3.utils.toWei('3000000000000');
   const votingDelay = new BN(4);
   const votingPeriod = new BN(16);
 
@@ -494,8 +498,11 @@ contract('GovernorCountingFractional', function (accounts) {
   });
 
   describe('Protects against voting weight overflow - FOR', function () {
-    // this weight cannot be stored as a uint80; type(uint80).max == 1.2e24
-    const voter1Weight = web3.utils.toWei('1300000'); // 1.3e24
+    // to test for overflow, we need a number of votes greater than the max we
+    // can store; currently votes are stored as uint80's but we also truncate 6
+    // digits of precision from them.
+    // type(uint80).max == 1.2e24, multiplying by 1e6 gives us 1.2e30
+    const voter1Weight = web3.utils.toWei('1300000000000'); // 1.3e30
     beforeEach(async function () {
       this.settings = {
         proposal: [
@@ -525,8 +532,11 @@ contract('GovernorCountingFractional', function (accounts) {
   });
 
   describe('Protects against voting weight overflow - AGAINST', function () {
-    // this weight cannot be stored as a uint80; type(uint80).max == 1.2e24
-    const voter1Weight = web3.utils.toWei('1300000'); // 1.3e24
+    // to test for overflow, we need a number of votes greater than the max we
+    // can store; currently votes are stored as uint80's but we also truncate 6
+    // digits of precision from them.
+    // type(uint80).max == 1.2e24, multiplying by 1e6 gives us 1.2e30
+    const voter1Weight = web3.utils.toWei('1300000000000'); // 1.3e30
     beforeEach(async function () {
       this.settings = {
         proposal: [
@@ -557,8 +567,11 @@ contract('GovernorCountingFractional', function (accounts) {
 
   describe('Protects against fractional voting weight overflow', function () {
     const voter1Weight = web3.utils.toWei('1.0');
-    // this weight cannot be stored as a uint80; type(uint80).max == 1.2e24
-    const voter2Weight = web3.utils.toWei('1300000'); // 1.3e24
+    // To test for overflow, we need a number of votes greater than the max we
+    // can store; currently votes are stored as uint80's but we also truncate 6
+    // digits of precision from them.
+    // type(uint80).max == 1.2e24, multiplying by 1e6 gives us 1.2e30
+    const voter2Weight = web3.utils.toWei('1300000000000'); // 1.3e30
     beforeEach(async function () {
       this.settings = {
         proposal: [

--- a/test/governance/extensions/GovernorCountingFractional.test.js
+++ b/test/governance/extensions/GovernorCountingFractional.test.js
@@ -1,9 +1,6 @@
 const { BN, expectEvent, expectRevert, time } = require('@openzeppelin/test-helpers');
 const { web3 } = require('@openzeppelin/test-helpers/src/setup');
 const Enums = require('../../helpers/enums');
-const Wallet = require('ethereumjs-wallet').default;
-const { EIP712Domain } = require('../../helpers/eip712');
-const { fromRpcSig } = require('ethereumjs-util');
 
 const { runGovernorWorkflow } = require('../GovernorWorkflow.behavior');
 const { expect, assert } = require('chai');
@@ -16,7 +13,6 @@ contract('GovernorCountingFractional', function (accounts) {
   const [owner, proposer, voter1, voter2, voter3, voter4] = accounts;
 
   const name = 'OZ-Governor';
-  const version = '1';
   const tokenName = 'MockToken';
   const tokenSymbol = 'MTKN';
   const tokenSupply = web3.utils.toWei('100');

--- a/test/governance/extensions/GovernorCountingFractional.test.js
+++ b/test/governance/extensions/GovernorCountingFractional.test.js
@@ -374,7 +374,6 @@ contract('GovernorCountingFractional', function (accounts) {
 
       const forVotes = new BN(voter2Weight).mul(new BN(98)).div(new BN(100)); // 98%
       const againstVotes = new BN(voter2Weight).mul(new BN(1)).div(new BN(100)); // 1%
-      const abstainVotes = new BN(voter2Weight).sub(forVotes).sub(againstVotes);
 
       const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
@@ -430,7 +429,6 @@ contract('GovernorCountingFractional', function (accounts) {
 
       const forVotes = new BN(voter2Weight).mul(new BN(1)).div(new BN(100)); // 1%
       const againstVotes = new BN(voter2Weight).mul(new BN(90)).div(new BN(100)); // 90%
-      const abstainVotes = new BN(voter2Weight).sub(forVotes).sub(againstVotes);
 
       const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
       const tx = await this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 });
@@ -483,7 +481,6 @@ contract('GovernorCountingFractional', function (accounts) {
 
       const forVotes = new BN(voter2Weight).mul(new BN(56)).div(new BN(100)); // 56%
       const againstVotes = new BN(voter2Weight).mul(new BN(90)).div(new BN(100)); // 90%
-      const abstainVotes = new BN(voter2Weight).sub(forVotes).sub(againstVotes);
 
       assert(forVotes.add(againstVotes).gt(new BN(voter2Weight)), 'test assumption not met');
 
@@ -518,7 +515,8 @@ contract('GovernorCountingFractional', function (accounts) {
             voter: voter1,
             weight: voter1Weight,
             support: Enums.VoteType.For,
-            error: "VM Exception while processing transaction: reverted with reason string 'SafeCast: value doesn't fit in 80 bits'",
+            error: 'VM Exception while processing transaction: reverted with ' +
+            'reason string \'SafeCast: value doesn\'t fit in 80 bits\'',
           },
         ],
         steps: {
@@ -552,7 +550,8 @@ contract('GovernorCountingFractional', function (accounts) {
             voter: voter1,
             weight: voter1Weight,
             support: Enums.VoteType.Against,
-            error: "VM Exception while processing transaction: reverted with reason string 'SafeCast: value doesn't fit in 80 bits'",
+            error: 'VM Exception while processing transaction: reverted with ' +
+            'reason string \'SafeCast: value doesn\'t fit in 80 bits\'',
           },
         ],
         steps: {
@@ -600,14 +599,13 @@ contract('GovernorCountingFractional', function (accounts) {
 
       const forVotes = new BN(voter2Weight);
       const againstVotes = new BN(0);
-      const abstainVotes = new BN(0);
 
       const initVotes = await this.mock.proposalVotes(this.id);
       const params = web3.eth.abi.encodeParameters(['uint128', 'uint128'], [forVotes, againstVotes]);
       // The EVM throws an exception that hardhat is unable to parse:
       //       "Transaction reverted and Hardhat couldn't infer the reason"
       await expectRevert.unspecified(
-        this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 })
+        this.mock.castVoteWithReasonAndParams(this.id, 0, '', params, { from: voter2 }),
       );
 
       // The important thing is that the call reverts and no vote counts are changed
@@ -694,9 +692,9 @@ contract('GovernorCountingFractional', function (accounts) {
   });
 
   describe('It correctly adds fractional votes after stripping precision', function () {
-    // we strip precision starting ...   v here
-    const voter1Weight =               '2999999';
-    const voter2Weight = '999999999999999000001';
+    // we strip precision  v here
+    const voter1Weight = '2999999';
+    const voter2Weight = '9000001';
     beforeEach(async function () {
       this.settings = {
         proposal: [
@@ -723,7 +721,7 @@ contract('GovernorCountingFractional', function (accounts) {
     afterEach(async function () {
       expect(await this.mock.state(this.id)).to.be.bignumber.equal(Enums.ProposalState.Active);
 
-      const forVotes = new BN('999999999999999000000');
+      const forVotes = new BN('9000000');
       const againstVotes = new BN('1');
       const abstainVotes = new BN(voter2Weight).sub(forVotes).sub(againstVotes);
 

--- a/test/utils/math/SafeCast.test.js
+++ b/test/utils/math/SafeCast.test.js
@@ -41,7 +41,7 @@ contract('SafeCast', async (accounts) => {
     });
   }
 
-  [8, 16, 32, 64, 96, 128, 224].forEach(bits => testToUint(bits));
+  [8, 16, 32, 64, 80, 96, 128, 224].forEach(bits => testToUint(bits));
 
   describe('toUint256', () => {
     const maxInt256 = new BN('2').pow(new BN(255)).subn(1);

--- a/test/utils/math/SafeCast.test.js
+++ b/test/utils/math/SafeCast.test.js
@@ -41,7 +41,7 @@ contract('SafeCast', async (accounts) => {
     });
   }
 
-  [8, 16, 32, 64, 80, 96, 128, 224].forEach(bits => testToUint(bits));
+  [8, 16, 32, 64, 80, 88, 96, 128, 224].forEach(bits => testToUint(bits));
 
   describe('toUint256', () => {
     const maxInt256 = new BN('2').pow(new BN(255)).subn(1);


### PR DESCRIPTION
Compare with #3 and #4

This is the most sophisticated approach to vote storage that we've considered. We store the different vote types (`for`, `against`, `abstain`) as three de-facto `uint85`s packed into 1 slot to save gas. Solidity does not have a `uint85` type, so we are manually bitshifting before we write and after we read the values from the slot to accomplish this. The max number that can fit in a `uint85` is ~3.9e25, and unfortunately that's not big enough to fit the votes from past proposals when you take into account governance token decimals -- e.g. with 100 mil votes cast and 18 decimals on the token, [this proposal](https://app.uniswap.org/#/vote/1/1?chain=mainnet) would have required putting ~1e26 in storage. To remedy this, we strip 3 digits of precision from the votes before storing them, giving us a max number of 3.9e28 votes per type.

From a high level, here are some stats on the approach:
* `castVoteWithReasonAndParams` costs 75115 gas on average
* max vote count per type is ~3.9e28
* we lose 3 decimals of precision on votes

Here's the full gas estimation report of the latest test run from hardhat:

```
·----------------------------------------------------------|---------------------------|-------------|-----------------------------·
|                   Solc version: 0.8.9                    ·  Optimizer enabled: true  ·  Runs: 200  ·  Block limit: 10000000 gas  │
···························································|···························|·············|······························
|  Methods                                                                                                                         │
···························|·······························|·············|·············|·············|···············|··············
|  Contract                ·  Method                       ·  Min        ·  Max        ·  Avg        ·  # calls      ·  usd (avg)  │
···························|·······························|·············|·············|·············|···············|··············
|  ERC20VotesMock          ·  delegate                     ·          -  ·          -  ·      48386  ·           80  ·          -  │
···························|·······························|·············|·············|·············|···············|··············
|  ERC20VotesMock          ·  mint                         ·          -  ·          -  ·     118134  ·           20  ·          -  │
···························|·······························|·············|·············|·············|···············|··············
|  ERC20VotesMock          ·  transfer                     ·     102971  ·     103067  ·     103019  ·           37  ·          -  │
···························|·······························|·············|·············|·············|···············|··············
|  GovernorFractionalMock  ·  castVote                     ·      71056  ·      88211  ·      84587  ·           19  ·          -  │
···························|·······························|·············|·············|·············|···············|··············
|  GovernorFractionalMock  ·  castVoteWithReason           ·          -  ·          -  ·      89520  ·            1  ·          -  │
···························|·······························|·············|·············|·············|···············|··············
|  GovernorFractionalMock  ·  castVoteWithReasonAndParams  ·      75013  ·      75169  ·      75115  ·           10  ·          -  │
···························|·······························|·············|·············|·············|···············|··············
|  GovernorFractionalMock  ·  execute                      ·          -  ·          -  ·      64134  ·            3  ·          -  │
···························|·······························|·············|·············|·············|···············|··············
|  GovernorFractionalMock  ·  propose                      ·      87694  ·      87706  ·      87705  ·           19  ·          -  │
···························|·······························|·············|·············|·············|···············|··············
|  Deployments                                             ·                                         ·  % of limit   ·             │
···························································|·············|·············|·············|···············|··············
|  CallReceiverMock                                        ·          -  ·          -  ·     342850  ·        3.4 %  ·          -  │
···························································|·············|·············|·············|···············|··············
|  ERC20VotesMock                                          ·          -  ·          -  ·    1753134  ·       17.5 %  ·          -  │
···························································|·············|·············|·············|···············|··············
|  GovernorFractionalMock                                  ·    2742059  ·    2742071  ·    2742070  ·       27.4 %  ·          -  │
·----------------------------------------------------------|-------------|-------------|-------------|---------------|-------------·

```

<!-- Thank you for your interest in contributing to OpenZeppelin! -->

<!-- Consider opening an issue for discussion prior to submitting a PR. -->
<!-- New features will be merged faster if they were first discussed and designed with the team. -->

Fixes #???? <!-- Fill in with issue number -->

<!-- Describe the changes introduced in this pull request. -->
<!-- Include any context necessary for understanding the PR's purpose. -->


#### PR Checklist

<!-- Before merging the pull request all of the following must be complete. -->
<!-- Feel free to submit a PR or Draft PR even if some items are pending. -->
<!-- Some of the items may not apply. -->

- [ ] Tests
- [ ] Documentation
- [ ] Changelog entry
